### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ sudo apt-get update
 sudo apt-get install python-dev git
 git clone https://github.com/eutim/OPI.GPIO
 cd OPI.GPIO
-sudo python setup.py install
+sudo python3 setup.py install
 ```
 ###### Usage
 * GPIO.setboard(GPIO.H616) # Orange Pi Zero2 board

--- a/source/boards.h
+++ b/source/boards.h
@@ -20,15 +20,15 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-const int pin_to_gpio_h616[41];
-const int pin_to_gpio_pi3[41];
-const int pin_to_gpio_lite2[41];
-const int pin_to_gpio_zero[41];
-const int pin_to_gpio_zero2[41];
-const int pin_to_gpio_pc[41];
-const int pin_to_gpio_pc2[41];
-const int pin_to_gpio_prime[41];
+extern const int pin_to_gpio_h616[41];
+extern const int pin_to_gpio_pi3[41];
+extern const int pin_to_gpio_lite2[41];
+extern const int pin_to_gpio_zero[41];
+extern const int pin_to_gpio_zero2[41];
+extern const int pin_to_gpio_pc[41];
+extern const int pin_to_gpio_pc2[41];
+extern const int pin_to_gpio_prime[41];
 
-const char* FUNCTIONS[41];
+extern const char* FUNCTIONS[41];
 
 int gpio_function_name(int gpio, int func, int board);

--- a/source/common.c
+++ b/source/common.c
@@ -27,6 +27,8 @@ SOFTWARE.
 
 int board_type = BOARD_UNKNOWN;
 int gpio_mode = MODE_UNKNOWN;
+const int (*pin_to_gpio)[41];
+int gpio_direction[383];
 int setup_error = 0;
 int module_setup = 0;
 

--- a/source/common.h
+++ b/source/common.h
@@ -44,13 +44,13 @@ SOFTWARE.
 
 #define ALT_UNKNOWN    -1
 
-int board_type;
-int gpio_mode;
-const int (*pin_to_gpio)[41];
+extern int board_type;
+extern int gpio_mode;
+extern const int (*pin_to_gpio)[41];
 
-int gpio_direction[383];
-int setup_error;
-int module_setup;
+extern int gpio_direction[383];
+extern int setup_error;
+extern int module_setup;
 
 int get_gpio_number(int channel, unsigned int *gpio);
 int check_gpio_priv(void);

--- a/source/constants.c
+++ b/source/constants.c
@@ -26,6 +26,32 @@ SOFTWARE.
 #include "c_gpio.h"
 #include "event_gpio.h"
 
+PyObject *high;
+PyObject *low;
+PyObject *input;
+PyObject *output;
+PyObject *pud_off;
+PyObject *pud_up;
+PyObject *pud_down;
+PyObject *rising_edge;
+PyObject *falling_edge;
+PyObject *both_edge;
+PyObject *unknown;
+PyObject *board;
+PyObject *bcm;
+PyObject *soc;
+PyObject *version;
+PyObject *bunknown;
+PyObject *bzeroh2;
+PyObject *bzeroh5;
+PyObject *bzeroplus3;
+PyObject *bpc;
+PyObject *bpc2;
+PyObject *bprime;
+PyObject *bh616;
+PyObject *blite2;
+PyObject *bpi3;
+
 void define_constants(PyObject *module)
 {
 	high = Py_BuildValue("i", HIGH);

--- a/source/constants.h
+++ b/source/constants.h
@@ -23,31 +23,31 @@ SOFTWARE.
 #define PY_PUD_CONST_OFFSET 20
 #define PY_EVENT_CONST_OFFSET 30
 
-PyObject *high;
-PyObject *low;
-PyObject *input;
-PyObject *output;
-PyObject *pud_off;
-PyObject *pud_up;
-PyObject *pud_down;
-PyObject *rising_edge;
-PyObject *falling_edge;
-PyObject *both_edge;
-PyObject *unknown;
-PyObject *board;
-PyObject *bcm;
-PyObject *soc;
-PyObject *version;
-PyObject *bunknown;
-PyObject *bzeroh2;
-PyObject *bzeroh5;
-PyObject *bzeroplus3;
-PyObject *bpc;
-PyObject *bpc2;
-PyObject *bprime;
-PyObject *bh616;
-PyObject *blite2;
-PyObject *bpi3;
+extern PyObject *high;
+extern PyObject *low;
+extern PyObject *input;
+extern PyObject *output;
+extern PyObject *pud_off;
+extern PyObject *pud_up;
+extern PyObject *pud_down;
+extern PyObject *rising_edge;
+extern PyObject *falling_edge;
+extern PyObject *both_edge;
+extern PyObject *unknown;
+extern PyObject *board;
+extern PyObject *bcm;
+extern PyObject *soc;
+extern PyObject *version;
+extern PyObject *bunknown;
+extern PyObject *bzeroh2;
+extern PyObject *bzeroh5;
+extern PyObject *bzeroplus3;
+extern PyObject *bpc;
+extern PyObject *bpc2;
+extern PyObject *bprime;
+extern PyObject *bh616;
+extern PyObject *blite2;
+extern PyObject *bpi3;
 
 
 void define_constants(PyObject *module);

--- a/source/py_pwm.h
+++ b/source/py_pwm.h
@@ -20,5 +20,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-PyTypeObject PWMType;
+extern PyTypeObject PWMType;
 PyTypeObject *PWM_init_PWMType(void);

--- a/source/soft_pwm.c
+++ b/source/soft_pwm.c
@@ -26,7 +26,7 @@ SOFTWARE.
 #include "c_gpio.h"
 #include "common.h"
 #include "soft_pwm.h"
-pthread_t threads;
+static pthread_t threads;
 
 struct pwm
 {


### PR DESCRIPTION
Implemented changes for Python 3.10 - per https://github.com/eutim/OPI.GPIO/issues/3
Compiled and tested on:
* Ubuntu 22.04.1
* Python 3.10.4
* OrangePi Zero 2
